### PR TITLE
Fix YAML syntax error in metrics.yml

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -31,6 +31,6 @@ jobs:
           plugin_isocalendar: yes
           plugin_isocalendar_duration: half-year
           plugin_languages: yes
-          plugin_languages_ignored:html, css
+          plugin_languages_ignored: html, css
           plugin_stars: yes
           plugin_stars_limit: 4


### PR DESCRIPTION
The metrics.yml workflow file contained a syntax error where `plugin_languages_ignored` was not followed by a space. This commit fixes the syntax by adding the required space, ensuring the YAML file is valid.

---
*PR created automatically by Jules for task [17122206269487230222](https://jules.google.com/task/17122206269487230222) started by @juninmd*